### PR TITLE
Pon not updated in getOutGradientShaders

### DIFF
--- a/src/Base.php
+++ b/src/Base.php
@@ -377,11 +377,12 @@ abstract class Base
      */
     public function getOutGradientShaders($pon)
     {
+        $this->pon = (int) $pon;
+
         if ($this->pdfa || empty($this->gradients)) {
             return '';
         }
 
-        $this->pon = (int) $pon;
         $idt = count($this->gradients); // index for transparency gradients
 
         $out = '';


### PR DESCRIPTION
Pon need to be updated before exiting the method, otherwise getObjectNumber can return old pon value.