### PR TITLE
Fix chr(): Providing a value not in-between 0 and 255 is deprecated

### DIFF
--- a/src/Gradient.php
+++ b/src/Gradient.php
@@ -655,9 +655,9 @@ abstract class Gradient extends \Com\Tecnick\Pdf\Graph\Raw
 
             foreach ($par['colors'] as $color) {
                 // each color component as 8 bit
-                $this->gradients[$ngr]['stream'] .= \chr((int) \floor($color['red'] * 255))
-                . \chr((int) \floor($color['green'] * 255))
-                . \chr((int) \floor($color['blue'] * 255));
+                $this->gradients[$ngr]['stream'] .= \chr(((int) \floor($color['red'] * 255)) % 256)
+                . \chr(((int) \floor($color['green'] * 255)) % 256)
+                . \chr(((int) \floor($color['blue'] * 255)) % 256);
             }
         }
 


### PR DESCRIPTION
Running test suite on 8.5

```
$ ./vendor/bin/phpunit test --no-coverage
PHPUnit 12.5.6 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.5.2
Configuration: /work/GIT/tc-lib-pdf-graph/phpunit.xml

.............................D................................... 65 / 81 ( 80%)
................                                                  81 / 81 (100%)

Time: 00:00.011, Memory: 6,00 MB

1 test triggered 3 PHP deprecations:

1) /work/GIT/tc-lib-pdf-graph/src/Gradient.php:658
chr(): Providing a value not in-between 0 and 255 is deprecated, this is because a byte value must be in the [0, 255] interval. The value used will be constrained using % 256

Triggered by:

* Test\GradientTest::testGetCoonsPatchMesh (3 times)
  /work/GIT/tc-lib-pdf-graph/test/GradientTest.php:218

2) /work/GIT/tc-lib-pdf-graph/src/Gradient.php:659
chr(): Providing a value not in-between 0 and 255 is deprecated, this is because a byte value must be in the [0, 255] interval. The value used will be constrained using % 256

Triggered by:

* Test\GradientTest::testGetCoonsPatchMesh (3 times)
  /work/GIT/tc-lib-pdf-graph/test/GradientTest.php:218

3) /work/GIT/tc-lib-pdf-graph/src/Gradient.php:660
chr(): Providing a value not in-between 0 and 255 is deprecated, this is because a byte value must be in the [0, 255] interval. The value used will be constrained using % 256

Triggered by:

* Test\GradientTest::testGetCoonsPatchMesh (4 times)
  /work/GIT/tc-lib-pdf-graph/test/GradientTest.php:218

OK, but there were issues!
Tests: 81, Assertions: 252, Deprecations: 3.

```